### PR TITLE
Mongo coordinate compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ yarn install
 bun install
 ```
 
+## Notes
+
+Since this project uses MongoDB to store geographical points, we have to store coordinates in `[lon, lat]` instead of `[lat, lon]`. However, Leaflet uses `[lat, lon]` to display the points on the map. Therefore, we have to reverse the coordinates when displaying them on the map. This is currently done wherever coordinate data is rendered, but other options could be better.
+
 ## Development Server
 
 Start the development server on `http://localhost:3000`:

--- a/components/DetailsDrawer.vue
+++ b/components/DetailsDrawer.vue
@@ -51,9 +51,9 @@
         </div>
         <h3 class="text-md font-semibold text-gray-800">Koordinaatit</h3>
         <div class="flex items-center space-x-2">
-          <p class="text-gray-600">{{ selectedSpot.coordinates.coordinates[0] }}</p>
-          ,
           <p class="text-gray-600">{{ selectedSpot.coordinates.coordinates[1] }}</p>
+          ,
+          <p class="text-gray-600">{{ selectedSpot.coordinates.coordinates[0] }}</p>
         </div>
 
         <h3 class="text-md font-semibold text-gray-800">Lisätty</h3>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -11,11 +11,17 @@
       @click="handleMapClick($event)"
     >
       <LControlZoom position="bottomright" />
+      <!-- TODO: Consider adding these to the tile layer to limit how much of the map is rendered -->
+      <!-- :no-wrap="true"
+        :bounds="[
+          [-90, -180],
+          [90, 180],
+        ]" -->
       <LTileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" layer-type="base" />
       <LMarker
         v-for="spot in fishingSpots"
         :key="spot._id"
-        :lat-lng="spot.coordinates.coordinates"
+        :lat-lng="[spot.coordinates.coordinates[1], spot.coordinates.coordinates[0]]"
         @click="() => handleMarkerClick(spot)"
         ref="markers"
       >
@@ -62,6 +68,7 @@ const zoom = ref(6);
 const mapOptions = {
   zoomControl: false,
   attributionControl: false, // TODO: See if hiding is really necessary or not, especially on desktop
+  worldCopyJump: true,
 };
 
 const tooltipOptions = {

--- a/server/api/flip-coordinates.js
+++ b/server/api/flip-coordinates.js
@@ -1,0 +1,28 @@
+import { FishingSpot } from '../models/spot.model';
+
+// export default defineEventHandler(async (event) => {
+//   // This is a one-time use route handler, that will flip the coordinates of all fishing spots in the database.
+//   // It's only used to fix the coordinates of the fishing spots that were saved in the wrong format.
+
+//   const spotsToUpdate = await FishingSpot.find();
+
+//   spotsToUpdate.map(async (spot) => {
+//     const flippedCoordinates = {
+//       ...spot.coordinates,
+//       coordinates: [spot.coordinates.coordinates[1], spot.coordinates.coordinates[0]],
+//     };
+
+//     console.log(
+//       'Updating spot: ',
+//       spot.name,
+//       'with coordinates: ',
+//       flippedCoordinates.coordinates,
+//       'from: ',
+//       spot.coordinates.coordinates,
+//       'to: ',
+//       flippedCoordinates.coordinates,
+//     );
+
+//     await FishingSpot.findByIdAndUpdate(spot._id, { coordinates: flippedCoordinates });
+//   });
+// });

--- a/server/api/v1/fishingspots/index.get.ts
+++ b/server/api/v1/fishingspots/index.get.ts
@@ -1,7 +1,22 @@
 import { FishingSpot } from '../../../models/spot.model';
 
-export default defineEventHandler((event) => {
-  const fishingSpots = FishingSpot.find();
+interface FishingSpot {
+  name: string;
+  description?: string;
+  coordinates: {
+    type: string;
+    coordinates: [number, number];
+  };
+  createdBy: string;
+}
+
+export default defineEventHandler(async (event) => {
+  const fishingSpots = (await FishingSpot.find()) as FishingSpot[];
+
+  // // Flip the coordinates back to the format the client expects
+  // fishingSpots.forEach((spot) => {
+  //   spot.coordinates.coordinates = [spot.coordinates.coordinates[1], spot.coordinates.coordinates[0]];
+  // });
 
   return fishingSpots;
 });

--- a/server/api/v1/fishingspots/index.post.ts
+++ b/server/api/v1/fishingspots/index.post.ts
@@ -23,12 +23,18 @@ export default defineEventHandler(async (event) => {
 
     const { name, description, coordinates } = body;
 
+    // Flip coordinates to match GeoJSON format
+    const flippedCoordinates = {
+      ...coordinates,
+      coordinates: [coordinates.coordinates[1], coordinates.coordinates[0]],
+    };
+
     const createdBy = CreatedByType.USER;
 
     const newFishingSpot = new FishingSpot({
       name,
       description,
-      coordinates,
+      coordinates: flippedCoordinates,
       createdBy,
     });
 
@@ -36,13 +42,13 @@ export default defineEventHandler(async (event) => {
 
     return {
       statusCode: 201,
-      body: JSON.stringify(savedSpot),
+      body: savedSpot,
     };
   } catch (error) {
     console.error('Error creating fishing spot:', error);
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Internal Server Error' }),
+      body: { error: 'Internal Server Error' },
     };
   }
 });


### PR DESCRIPTION
Use reversed coordinates (`[lon, lat]` instead of `[lat, lon]`) for maximum compatibility with Mongo's geospatial queries. https://www.mongodb.com/docs/manual/geospatial-queries/